### PR TITLE
Add route history implementation and test

### DIFF
--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
@@ -99,7 +99,7 @@ public class MessageListener {
         RouteHistory routingStep = new RouteHistory(type, id, ZonedDateTime.now());
         List<RouteHistory> history = cloudEvent.getRoute().map(route -> new ArrayList<>(route)).orElse(new ArrayList<>());
         history.add(routingStep);
-        return cloudEvent.copy().setRoute(history);
+        return new MicoCloudEventImpl<JsonNode>(cloudEvent).setRoute(history);
     }
 
     /**

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
@@ -7,6 +7,7 @@ import io.github.ust.mico.kafkafaasconnector.configuration.KafkaConfig;
 import io.github.ust.mico.kafkafaasconnector.configuration.OpenFaaSConfig;
 import io.github.ust.mico.kafkafaasconnector.kafka.ErrorReportMessage;
 import io.github.ust.mico.kafkafaasconnector.kafka.MicoCloudEventImpl;
+import io.github.ust.mico.kafkafaasconnector.kafka.RouteHistory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -95,8 +96,10 @@ public class MessageListener {
      * @return the updated cloud event
      */
     public MicoCloudEventImpl<JsonNode> updateRouteHistory(MicoCloudEventImpl<JsonNode> cloudEvent, String id, String type) {
-        // TODO update route history here
-        return cloudEvent;
+        RouteHistory routingStep = new RouteHistory(type, id, ZonedDateTime.now());
+        List<RouteHistory> history = cloudEvent.getRoute().map(route -> new ArrayList<>(route)).orElse(new ArrayList<>());
+        history.add(routingStep);
+        return cloudEvent.copy().setRoute(history);
     }
 
     /**
@@ -152,22 +155,18 @@ public class MessageListener {
      * @param cloudEvent the cloud event to send
      */
     public void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent) {
-        try {
-            Optional<List<ArrayList<String>>> routingSlip = cloudEvent.getRoutingSlip();
-            List<ArrayList<String>> newRoutingSlip = routingSlip.orElse(new ArrayList<>());
-            ArrayList<String> destinations = newRoutingSlip.get(newRoutingSlip.size() - 1);
-            newRoutingSlip.remove(newRoutingSlip.size() - 1);
+        List<List<String>> routingSlip = cloudEvent.getRoutingSlip().orElse(new ArrayList<>());
+        if (routingSlip.size() > 0) {
+            List<String> destinations = routingSlip.get(routingSlip.size() - 1);
+            routingSlip.remove(routingSlip.size() - 1);
             // Check if valid topic?
             for (String topic : destinations) {
                 this.sendCloudEvent(cloudEvent, topic);
             }
-        } catch (NullPointerException e) {
-            log.error("Failed to find a routing slip in the CloudEvent '{}'.", cloudEvent);
-        } catch (IndexOutOfBoundsException e) {
-            log.error("There is no next topic on the routing slip.");
+        } else {
+            // default case:
+            this.sendCloudEvent(cloudEvent, this.kafkaConfig.getOutputTopic());
         }
-        // default case:
-        this.sendCloudEvent(cloudEvent, this.kafkaConfig.getOutputTopic());
     }
 
     /**

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -40,14 +40,14 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
 
     private String correlationId;
     private String createFrom;
-    private String route;
-    private List<ArrayList<String>> routingSlip;
+    private List<RouteHistory> route;
+    private List<List<String>> routingSlip;
     private boolean isTestMessage;
     private String filterOutBeforeTopic;
     private ZonedDateTime expiryDate;
     private String sequenceId;
-    private String sequenceNumber;
-    private String sequenceSize;
+    private Integer sequenceNumber;
+    private Integer sequenceSize;
     private String returnTopic;
     private String dataRef;
 
@@ -68,6 +68,37 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
         extensions = cloudEvent.getExtensions().orElse(null);
         time = cloudEvent.getTime().orElse(null);
         return this;
+    }
+
+    /**
+     * Create a shallow copy of this cloud event.
+     *
+     * @return the copy
+     */
+    public MicoCloudEventImpl<T> copy() {
+        MicoCloudEventImpl<T> ce = new MicoCloudEventImpl<>();
+        // TODO this list needs to be manually maintained!
+        ce.id = this.id;
+        ce.source = this.source;
+        ce.type = this.type;
+        ce.time = this.time;
+        ce.schemaURL = this.schemaURL;
+        ce.contentType = this.contentType;
+        ce.data = this.data;
+        ce.extensions = this.extensions;
+        ce.correlationId = this.correlationId;
+        ce.createFrom = this.createFrom;
+        ce.route = this.route;
+        ce.routingSlip = this.routingSlip;
+        ce.isTestMessage = this.isTestMessage;
+        ce.filterOutBeforeTopic = this.filterOutBeforeTopic;
+        ce.expiryDate = this.expiryDate;
+        ce.sequenceId = this.sequenceId;
+        ce.sequenceNumber = this.sequenceNumber;
+        ce.sequenceSize = this.sequenceSize;
+        ce.returnTopic = this.returnTopic;
+        ce.dataRef = this.dataRef;
+        return ce;
     }
 
     @JsonAnySetter
@@ -109,11 +140,11 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
         return Optional.ofNullable(createFrom);
     }
 
-    public Optional<String> getRoute() {
+    public Optional<List<RouteHistory>> getRoute() {
         return Optional.ofNullable(route);
     }
 
-    public Optional<List<ArrayList<String>>> getRoutingSlip() {
+    public Optional<List<List<String>>> getRoutingSlip() {
         return Optional.ofNullable(routingSlip);
     }
 
@@ -133,11 +164,11 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
         return Optional.ofNullable(sequenceId);
     }
 
-    public Optional<String> getSequenceNumber() {
+    public Optional<Integer> getSequenceNumber() {
         return Optional.ofNullable(sequenceNumber);
     }
 
-    public Optional<String> getSequenceSize() {
+    public Optional<Integer> getSequenceSize() {
         return Optional.ofNullable(sequenceSize);
     }
 

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -51,6 +51,37 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
     private String returnTopic;
     private String dataRef;
 
+    /**
+     * Copy constructor providing a shallow copy of the cloud event.
+     *
+     * @param cloudEvent the event to copy
+     */
+    public MicoCloudEventImpl(MicoCloudEventImpl<T> cloudEvent) {
+        this(
+            cloudEvent.id,
+            cloudEvent.source,
+            cloudEvent.type,
+            cloudEvent.specVersion,
+            cloudEvent.time,
+            cloudEvent.schemaURL,
+            cloudEvent.contentType,
+            cloudEvent.data,
+            cloudEvent.extensions,
+            cloudEvent.correlationId,
+            cloudEvent.createFrom,
+            cloudEvent.route,
+            cloudEvent.routingSlip,
+            cloudEvent.isTestMessage,
+            cloudEvent.filterOutBeforeTopic,
+            cloudEvent.expiryDate,
+            cloudEvent.sequenceId,
+            cloudEvent.sequenceNumber,
+            cloudEvent.sequenceSize,
+            cloudEvent.returnTopic,
+            cloudEvent.dataRef
+        );
+    }
+
     public MicoCloudEventImpl<T> setRandomId() {
         id = UUID.randomUUID().toString();
         return this;
@@ -68,37 +99,6 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
         extensions = cloudEvent.getExtensions().orElse(null);
         time = cloudEvent.getTime().orElse(null);
         return this;
-    }
-
-    /**
-     * Create a shallow copy of this cloud event.
-     *
-     * @return the copy
-     */
-    public MicoCloudEventImpl<T> copy() {
-        MicoCloudEventImpl<T> ce = new MicoCloudEventImpl<>();
-        // TODO this list needs to be manually maintained!
-        ce.id = this.id;
-        ce.source = this.source;
-        ce.type = this.type;
-        ce.time = this.time;
-        ce.schemaURL = this.schemaURL;
-        ce.contentType = this.contentType;
-        ce.data = this.data;
-        ce.extensions = this.extensions;
-        ce.correlationId = this.correlationId;
-        ce.createFrom = this.createFrom;
-        ce.route = this.route;
-        ce.routingSlip = this.routingSlip;
-        ce.isTestMessage = this.isTestMessage;
-        ce.filterOutBeforeTopic = this.filterOutBeforeTopic;
-        ce.expiryDate = this.expiryDate;
-        ce.sequenceId = this.sequenceId;
-        ce.sequenceNumber = this.sequenceNumber;
-        ce.sequenceSize = this.sequenceSize;
-        ce.returnTopic = this.returnTopic;
-        ce.dataRef = this.dataRef;
-        return ce;
     }
 
     @JsonAnySetter

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/RouteHistory.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/RouteHistory.java
@@ -1,0 +1,35 @@
+package io.github.ust.mico.kafkafaasconnector.kafka;
+
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+@JsonDeserialize(as = RouteHistory.class)
+public class RouteHistory {
+
+    private String type;
+    private String id;
+    private ZonedDateTime timestamp;
+
+    public Optional<String> getType() {
+        return Optional.ofNullable(this.type);
+    }
+
+    public Optional<String> getId() {
+        return Optional.ofNullable(this.id);
+    }
+
+    public Optional<ZonedDateTime> getTimestamp() {
+        return Optional.ofNullable(this.timestamp);
+    }
+}

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/TestConstants.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/TestConstants.java
@@ -83,12 +83,9 @@ public class TestConstants {
      * @return
      */
     public static MicoCloudEventImpl<JsonNode> addSingleTopicRoutingStep(MicoCloudEventImpl<JsonNode> message, String topic) {
-        Optional<List<ArrayList<String>>> routingSlip = message.getRoutingSlip();
-        List<ArrayList<String>> newRoutingSlip = routingSlip.orElse(new ArrayList<>());
-        ArrayList<String> destinations = new ArrayList();
+        ArrayList<String> destinations = new ArrayList<>();
         destinations.add(topic);
-        newRoutingSlip.add(destinations);
-        return message.setRoutingSlip(newRoutingSlip);
+        return addMultipleTopicRoutingSteps(message, destinations);
     }
 
     /**
@@ -100,9 +97,9 @@ public class TestConstants {
      * @param destinations
      * @return
      */
-    public static MicoCloudEventImpl<JsonNode> addMultipleTopicRoutingSteps(MicoCloudEventImpl<JsonNode> message, ArrayList<String> destinations) {
-        Optional<List<ArrayList<String>>> routingSlip = message.getRoutingSlip();
-        List<ArrayList<String>> newRoutingSlip = routingSlip.orElse(new ArrayList<>());
+    public static MicoCloudEventImpl<JsonNode> addMultipleTopicRoutingSteps(MicoCloudEventImpl<JsonNode> message, List<String> destinations) {
+        Optional<List<List<String>>> routingSlip = message.getRoutingSlip();
+        List<List<String>> newRoutingSlip = routingSlip.orElse(new ArrayList<>());
         newRoutingSlip.add(destinations);
         return message.setRoutingSlip(newRoutingSlip);
     }
@@ -138,14 +135,17 @@ public class TestConstants {
      */
     public static MicoCloudEventImpl<JsonNode> setSequenceAttributes(MicoCloudEventImpl<JsonNode> message, String sequenceId, int sequenceNumber, int sequenceSize) {
         return message.setSequenceId(sequenceId)
-            .setSequenceSize(String.valueOf(sequenceSize))
-            .setSequenceNumber(String.valueOf(sequenceNumber));
+            .setSequenceSize(sequenceSize)
+            .setSequenceNumber(sequenceNumber);
     }
 
     // Kafka
 
     /**
      * Get a kafka consumer for testing with an embedded broker.
+     *
+     * The consumer needs to be unsubscribed after the test is finished.
+     * If not other tests using the same broker may fail to get messages!
      *
      * @param embeddedKafka the embedded kafka broker
      * @return


### PR DESCRIPTION
Adds shallow copy method for cloud events (for sending the message to multiple destinations)

Fixes RoutingSlip (would also route to default output...)
Fixes some types (some cloud event headers had the wrong types)