### PR TITLE
Feature/mico#730 missing header fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,12 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.exparity</groupId>
+            <artifactId>hamcrest-date</artifactId>
+            <version>2.0.5</version>
+            <scope>test</scope>
+        </dependency>
 		<dependency>
 			<groupId>org.springframework.kafka</groupId>
 			<artifactId>spring-kafka-test</artifactId>

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
@@ -68,6 +68,10 @@ public class MessageListener {
     @KafkaListener(topics = "${kafka.input-topic}")
     public void receive(MicoCloudEventImpl<JsonNode> cloudEvent) {
         log.debug("Received CloudEvent message: {}", cloudEvent);
+
+        //Save the message Id because some faas functions create need messages with different ids.
+        String originalMessageId = cloudEvent.getId();
+
         if (!cloudEvent.getData().isPresent()) {
             // data is entirely optional
             log.debug("Received message does not include any data!");
@@ -76,11 +80,11 @@ public class MessageListener {
             log.debug("Received expired message!");
         } else if (this.openFaaSConfig.isSkipFunctionCall()) {
             // when skipping the openFaaS function just pass on the original cloudEvent
-            this.sendCloudEvent(cloudEvent);
+            this.sendCloudEvent(cloudEvent, originalMessageId);
         } else {
             String functionResult = callFaasFunction(cloudEvent);
             ArrayList<MicoCloudEventImpl<JsonNode>> events = parseFunctionResult(functionResult, cloudEvent);
-            events.forEach(this::sendCloudEvent);
+            events.forEach(event -> this.sendCloudEvent(event,originalMessageId));
         }
     }
 
@@ -173,18 +177,18 @@ public class MessageListener {
      *
      * @param cloudEvent the cloud event to send
      */
-    public void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent) {
+    public void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent, String originalMessageId) {
         List<List<String>> routingSlip = cloudEvent.getRoutingSlip().orElse(new ArrayList<>());
         if (routingSlip.size() > 0) {
             List<String> destinations = routingSlip.get(routingSlip.size() - 1);
             routingSlip.remove(routingSlip.size() - 1);
             // Check if valid topic?
             for (String topic : destinations) {
-                this.sendCloudEvent(cloudEvent, topic);
+                this.sendCloudEvent(cloudEvent, topic, originalMessageId);
             }
         } else {
             // default case:
-            this.sendCloudEvent(cloudEvent, this.kafkaConfig.getOutputTopic());
+            this.sendCloudEvent(cloudEvent, this.kafkaConfig.getOutputTopic(), originalMessageId);
         }
     }
 
@@ -196,10 +200,11 @@ public class MessageListener {
      * @param cloudEvent the cloud event to send
      * @param topic      the kafka topic to send the cloud event to
      */
-    private void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent, String topic) {
+    private void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent, String topic, String originalMessageId) {
         cloudEvent = this.updateRouteHistoryWithTopic(cloudEvent, topic);
         // TODO commit logic/transactions
-        setMissingHeaderFields(cloudEvent);
+        setMissingHeaderFields(cloudEvent, originalMessageId);
+
         if (!isTestMessageCompleted(cloudEvent,topic)){
             log.debug("Is not necessary to filter the message. Is test message '{}', filterOutBeforeTopic: '{}', targetTopic: '{}'", cloudEvent.isTestMessage(), cloudEvent.getFilterOutBeforeTopic(), topic);
             kafkaTemplate.send(topic, cloudEvent);
@@ -264,10 +269,11 @@ public class MessageListener {
     }
 
     /**
-     * Sets the time and the Id field of a CloudEvent message if missing
+     * Sets the time, the correlationId and the Id field of a CloudEvent message if missing
      * @param cloudEvent
+     * @param originalMessageId
      */
-    public void setMissingHeaderFields(MicoCloudEventImpl<JsonNode> cloudEvent){
+    public void setMissingHeaderFields(MicoCloudEventImpl<JsonNode> cloudEvent, String originalMessageId){
         if(StringUtils.isEmpty(cloudEvent.getId())){
             cloudEvent.setRandomId();
             log.debug("Added missing id '{}' to cloud event", cloudEvent.getId());
@@ -275,6 +281,9 @@ public class MessageListener {
         if(!cloudEvent.getTime().isPresent()){
             cloudEvent.setTime(ZonedDateTime.now());
             log.debug("Added missing time '{}' to cloud event", cloudEvent.getTime().orElse(null));
+        }
+        if(!cloudEvent.getCorrelationId().isPresent()){
+            cloudEvent.setCorrelationId(originalMessageId);
         }
     }
 }

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -70,6 +70,7 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
     private Integer sequenceSize;
     private String returnTopic;
     private String dataRef;
+    private String subject;
 
     /**
      * Copy constructor providing a shallow copy of the cloud event.
@@ -98,7 +99,8 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
             cloudEvent.sequenceNumber,
             cloudEvent.sequenceSize,
             cloudEvent.returnTopic,
-            cloudEvent.dataRef
+            cloudEvent.dataRef,
+            cloudEvent.subject
         );
     }
 
@@ -198,5 +200,9 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
 
     public Optional<String> getDataRef() {
         return Optional.ofNullable(dataRef);
+    }
+
+    public Optional<String> getSubject() {
+        return Optional.ofNullable(subject);
     }
 }

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -34,6 +34,10 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.*;
 
+
+/**
+ * For more information read https://mico-docs.readthedocs.io/en/latest/messaging/cloudevents.html
+ */
 @Data
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/MessageListenerTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/MessageListenerTests.java
@@ -345,5 +345,45 @@ public class MessageListenerTests {
         MicoKafkaTestHelper.unsubscribeConsumer(consumer);
     }
 
+    /**
+     * Tests if a missing correlation header is set correctly
+     */
+    @Test
+    public void testMissingCorrelationId() {
+        Consumer<String, MicoCloudEventImpl<JsonNode>> consumer = micoKafkaTestHelper.getKafkaConsumer(kafkaConfig.getOutputTopic());
+
+        MicoCloudEventImpl<JsonNode> cloudEventSimple = CloudEventTestUtils.basicCloudEventWithRandomId();
+        final String messageId = cloudEventSimple.getId();
+
+        ConsumerRecord<String, MicoCloudEventImpl<JsonNode>> eventWithCorrelationId = micoKafkaTestHelper.exchangeMessage(consumer, kafkaConfig.getOutputTopic(), cloudEventSimple);
+        MicoCloudEventImpl<JsonNode> cloudEvent = eventWithCorrelationId.value();
+
+        assertThat("The correlationId should equal the id of the original message", cloudEvent.getCorrelationId().orElse(""), is(messageId));
+
+        // Don't forget to detach the consumer from kafka!
+        MicoKafkaTestHelper.unsubscribeConsumer(consumer);
+    }
+
+    /**
+     * Tests if a missing correlation is unchanged of set
+     */
+    @Test
+    public void testCorrelationIdUnChanged() {
+        Consumer<String, MicoCloudEventImpl<JsonNode>> consumer = micoKafkaTestHelper.getKafkaConsumer(kafkaConfig.getOutputTopic());
+
+        MicoCloudEventImpl<JsonNode> cloudEventSimple = CloudEventTestUtils.basicCloudEventWithRandomId();
+        String testCorrelationId = "testCorrelationId";
+        cloudEventSimple.setCorrelationId(testCorrelationId);
+
+        ConsumerRecord<String, MicoCloudEventImpl<JsonNode>> eventWithCorrelationId = micoKafkaTestHelper.exchangeMessage(consumer, kafkaConfig.getOutputTopic(), cloudEventSimple);
+        MicoCloudEventImpl<JsonNode> cloudEvent = eventWithCorrelationId.value();
+
+        assertThat("The correlationId should be unchanged", cloudEvent.getCorrelationId().orElse(""), is(testCorrelationId));
+
+        // Don't forget to detach the consumer from kafka!
+        MicoKafkaTestHelper.unsubscribeConsumer(consumer);
+    }
+
+
 
 }

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestUtils.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestUtils.java
@@ -112,4 +112,14 @@ public class MicoKafkaTestUtils {
             TestConstants.ROUTING_TOPIC_4));
         return requiredTopics;
     }
+
+    /**
+     * Generates a consumer based on the given topics
+     * @return
+     */
+    public static Consumer<String, MicoCloudEventImpl<JsonNode>> getKafkaConsumer(EmbeddedKafkaBroker embeddedKafka, String... topics) {
+        Consumer<String, MicoCloudEventImpl<JsonNode>> consumer = MicoKafkaTestUtils.getKafkaConsumer(embeddedKafka);
+        embeddedKafka.consumeFromEmbeddedTopics(consumer, topics);
+        return consumer;
+    }
 }

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestUtils.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestUtils.java
@@ -7,6 +7,7 @@ import io.github.ust.mico.kafkafaasconnector.kafka.CloudEventSerializer;
 import io.github.ust.mico.kafkafaasconnector.kafka.MicoCloudEventImpl;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -15,6 +16,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import java.util.Arrays;
 import java.util.HashSet;

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/TestConstants.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/TestConstants.java
@@ -54,4 +54,5 @@ public class TestConstants {
     public static String ROUTING_TOPIC_3 = "route-3";
     public static String ROUTING_TOPIC_4 = "route-4";
 
+    public static long DEFAULT_KAFKA_POLL_TIMEOUT = 1000;
 }


### PR DESCRIPTION
# Description

Adds the handling of messages without time and id. The missing header fields will be added before sending the message.

Still TODO:
- Add logic for createdFrom ( will be in a new pr)

# Resolves / is related to

 [#730](https://github.com/UST-MICO/mico/issues/730)

# Checklist

- [X] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
