### PR TITLE
Fix cloud events not serializing with lowercase attributes

### DIFF
--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -19,10 +19,12 @@
 
 package io.github.ust.mico.kafkafaasconnector.kafka;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+
 import io.cloudevents.CloudEvent;
 import io.cloudevents.Extension;
 import lombok.AllArgsConstructor;
@@ -43,6 +45,7 @@ import java.util.*;
 @AllArgsConstructor
 @Accessors(chain = true)
 @JsonDeserialize(as = MicoCloudEventImpl.class)
+@JsonNaming(value = PropertyNamingStrategy.LowerCaseStrategy.class)
 public class MicoCloudEventImpl<T> implements CloudEvent<T> {
 
     protected static final String SPEC_VERSION = "0.2";
@@ -51,7 +54,6 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
     private String id;
     private URI source;
     private String type;
-    @JsonAlias({"specversion"})
     private String specVersion = SPEC_VERSION;
 
 


### PR DESCRIPTION
# Description

The cloud event spec uses all lowercase attributes

- [ ] this PR contains breaking changes!

# Resolves / is related to

Fixes #8

# What is affected by this PR

- [ ] OpenFaaS Function Exchange Format
- [x] Message Format
- [ ] Documentation ([Doc repository](https://github.com/UST-MICO/docs))

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
