### PR TITLE
Feature/745 env var config

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,20 @@ Restart it by deleting the Kubernetes pod:
 ```bash
 kubectl -n $NAMESPACE delete pod $(kubectl get pods -n $NAMESPACE --selector=run=kafka-faas-connector --output=jsonpath={.items..metadata.name})
 ```
+
+## Environment Variables
+| Variable                          | Description                                                                      | Default Value            |
+|-----------------------------------|----------------------------------------------------------------------------------|--------------------------|
+| APPLICATION_NAME                  | The spring application name                                                      | kafka-faas-connector     |
+| APPLICATION_PORT                  | The server port                                                                  | 8080                     |
+| LOGGING_LEVEL_KAFKAFAASCONNECTOR  | Logging level of the Kafka-FaaS-Connector                                        | DEBUG                    |
+| LOGGING_LEVEL_KAFKA_CONSUMER_INFO | Logging level of the kafka consumer                                              | INFO                     |
+| KAFKA_BOOTSTRAP_SERVERS           | The URLs of the bootstrap servers                                                | localhost:9092           |
+| KAFKA_GROUP_ID                    | The group id for kafka                                                           | mico                     |
+| KAFKA_TOPIC_INPUT                 | The topic, on which the Kafka-Faas-Connector receives messages                   | transform-request        |
+| KAFKA_TOPIC_OUTPUT                | The topic, to which the kafka-faas-connector forwards the processed messages     | transform-result         |
+| KAFKA_TOPIC_INVALID_MESSAGE       | The topic, to which invalid messages are forwarded                               | InvalidMessage           |
+| KAFKA_TOPIC_DEAD_LETTER           | The topic, to which messages are forwarded that can't/shouldn't be delivered     | DeadLetter               |
+| KAFKA_TOPIC_TEST_MESSAGE_OUTPUT   | The topic, to which test messages are forwarded                                  | TestMessagesOutput       |
+| OPENFAAS_GATEWAY                  | The URL of the OpenFaaS gateway                                                  | http://127.0.0.1:8080    |
+| OPENFAAS_FUNCTION_NAME            | The name of the OpenFaaS function that shall be used for processing the messages | faas-message-transformer |

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
 			<artifactId>cloudevents-api</artifactId>
 			<version>0.2.1</version>
 		</dependency>
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <version>1.19.0</version>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,22 +18,22 @@
 #
 
 # Application
-spring.application.name=kafka-faas-connector
-server.port=8080
+spring.application.name=${APPLICATION_NAME:kafka-faas-connector}
+server.port=${APPLICATION_PORT:8080}
 
 # Logging
-logging.level.io.github.ust.mico.kafkafaasconnector=DEBUG
-logging.level.org.apache.kafka.clients.consumer=INFO
+logging.level.io.github.ust.mico.kafkafaasconnector=${LOGGING_LEVEL_KAFKAFAASCONNECTOR:DEBUG}
+logging.level.org.apache.kafka.clients.consumer=${LOGGING_LEVEL_KAFKA_CONSUMER:INFO}
 
 # Actuator
 management.endpoints.web.exposure.include=configprops,env,health,info,loggers,metrics
 
-kafka.bootstrap-servers=localhost:9092
-kafka.group-id=mico
-kafka.input-topic=transform-request
-kafka.output-topic=transform-result
-kafka.invalid-message-topic=InvalidMessage
-kafka.dead-letter-topic=DeadLetter
-kafka.test-message-output-topic=TestMessagesOutput
-openfaas.gateway=http://127.0.0.1:8080
-openfaas.function-name=faas-message-transformer
+kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:${spring.embedded.kafka.brokers}}
+kafka.group-id=${KAFKA_GROUP_ID:mico}
+kafka.input-topic=${KAFKA_TOPIC_INPUT:transform-request}
+kafka.output-topic=${KAFKA_TOPIC_OUTPUT:transform-result}
+kafka.invalid-message-topic=${KAFKA_TOPIC_INVALID_MESSAGE:InvalidMessage}
+kafka.dead-letter-topic=${KAFKA_TOPIC_DEAD_LETTER:DeadLetter}
+kafka.test-message-output-topic=${KAFKA_TOPIC_TEST_MESSAGE_OUTPUT:TestMessagesOutput}
+openfaas.gateway=${OPENFAAS_GATEWAY:http://127.0.0.1:8080}
+openfaas.function-name=${OPENFAAS_FUNCTION_NAME:faas-message-transformer}

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.github.ust.mico.kafkafaasconnector;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.github.ust.mico.kafkafaasconnector.configuration.KafkaConfig;
+import io.github.ust.mico.kafkafaasconnector.kafka.MicoCloudEventImpl;
+import org.junit.*;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import io.github.ust.mico.kafkafaasconnector.configuration.OpenFaaSConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import javax.annotation.PostConstruct;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@EnableAutoConfiguration
+@AutoConfigureMockMvc
+@DirtiesContext
+@Slf4j
+public class ConfigurationTests {
+
+    @Autowired
+    private OpenFaaSConfig openFaaSConfig;
+
+    @Autowired
+    private KafkaConfig kafkaConfig;
+
+    private final EmbeddedKafkaBroker embeddedKafka = broker.getEmbeddedKafka();
+
+//     https://docs.spring.io/spring-kafka/docs/2.2.6.RELEASE/reference/html/#kafka-testing-junit4-class-rule
+    @ClassRule
+    public static EmbeddedKafkaRule broker = new EmbeddedKafkaRule(1, false);
+
+    private KafkaTemplate<String, MicoCloudEventImpl<JsonNode>> template;
+    private MicoKafkaTestHelper micoKafkaTestHelper;
+
+    @ClassRule
+    public static final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+        .set("OPENFAAS_FUNCTION_NAME", "config_openfaas_func")
+        .set("OPENFAAS_GATEWAY","config_openfaas_gateway")
+        .set("KAFKA_GROUP_ID", "kafka_group_id")
+        .set("KAFKA_TOPIC_INPUT", "config_kafka_in")
+        .set("KAFKA_TOPIC_INVALID_MESSAGE", "config_kafka_invalid")
+        .set("KAFKA_TOPIC_OUTPUT", "config_kafka_out")
+        .set("KAFKA_TOPIC_DEAD_LETTER", "config_kafka_dead_letter")
+        .set("KAFKA_TOPIC_TEST_MESSAGE_OUTPUT", "test_msg");
+
+    @PostConstruct
+    public void before(){
+        this.micoKafkaTestHelper = new MicoKafkaTestHelper(embeddedKafka,kafkaConfig);
+        template = this.micoKafkaTestHelper.getTemplate();
+        //We need to add them outside of the rule because the autowired kakfaConfig is not accessible from the static rule
+        //We can not use @BeforeClass which is only executed once because it has to be static and we do not have access to the autowired kakfaConfig
+
+        Set<String> requiredTopics = this.micoKafkaTestHelper.getRequiredTopics();
+        Set<String> alreadySetTopics = this.micoKafkaTestHelper.requestActuallySetTopics();
+        requiredTopics.removeAll(alreadySetTopics);
+        requiredTopics.forEach(topic -> embeddedKafka.addTopics(topic));
+    }
+
+    @Test
+    public void testOpenFaaSConfig() {
+        assertThat(System.getenv("OPENFAAS_FUNCTION_NAME"), is(openFaaSConfig.getFunctionName()));
+        assertThat(System.getenv("OPENFAAS_GATEWAY"), is(openFaaSConfig.getGateway()));
+    }
+
+    @Test
+    public void testKafkaConfig() {
+        assertThat(System.getenv("KAFKA_GROUP_ID"), is(kafkaConfig.getGroupId()));
+        assertThat(System.getenv("KAFKA_TOPIC_INPUT"), is(kafkaConfig.getInputTopic()));
+        assertThat(System.getenv("KAFKA_TOPIC_OUTPUT"), is(kafkaConfig.getOutputTopic()));
+        assertThat(System.getenv("KAFKA_TOPIC_INVALID_MESSAGE"), is(kafkaConfig.getInvalidMessageTopic()));
+        assertThat(System.getenv("KAFKA_TOPIC_DEAD_LETTER"), is(kafkaConfig.getDeadLetterTopic()));
+        assertThat(System.getenv("KAFKA_TOPIC_TEST_MESSAGE_OUTPUT"), is(kafkaConfig.getTestMessageOutputTopic()));
+    }
+}

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
@@ -96,17 +96,17 @@ public class ConfigurationTests {
 
     @Test
     public void testOpenFaaSConfig() {
-        assertThat(System.getenv("OPENFAAS_FUNCTION_NAME"), is(openFaaSConfig.getFunctionName()));
-        assertThat(System.getenv("OPENFAAS_GATEWAY"), is(openFaaSConfig.getGateway()));
+        assertThat("config_openfaas_func", is(openFaaSConfig.getFunctionName()));
+        assertThat("config_openfaas_gateway", is(openFaaSConfig.getGateway()));
     }
 
     @Test
     public void testKafkaConfig() {
-        assertThat(System.getenv("KAFKA_GROUP_ID"), is(kafkaConfig.getGroupId()));
-        assertThat(System.getenv("KAFKA_TOPIC_INPUT"), is(kafkaConfig.getInputTopic()));
-        assertThat(System.getenv("KAFKA_TOPIC_OUTPUT"), is(kafkaConfig.getOutputTopic()));
-        assertThat(System.getenv("KAFKA_TOPIC_INVALID_MESSAGE"), is(kafkaConfig.getInvalidMessageTopic()));
-        assertThat(System.getenv("KAFKA_TOPIC_DEAD_LETTER"), is(kafkaConfig.getDeadLetterTopic()));
-        assertThat(System.getenv("KAFKA_TOPIC_TEST_MESSAGE_OUTPUT"), is(kafkaConfig.getTestMessageOutputTopic()));
+        assertThat("kafka_group_id", is(kafkaConfig.getGroupId()));
+        assertThat("config_kafka_in", is(kafkaConfig.getInputTopic()));
+        assertThat("config_kafka_out", is(kafkaConfig.getOutputTopic()));
+        assertThat("config_kafka_invalid", is(kafkaConfig.getInvalidMessageTopic()));
+        assertThat("config_kafka_dead_letter", is(kafkaConfig.getDeadLetterTopic()));
+        assertThat("test_msg", is(kafkaConfig.getTestMessageOutputTopic()));
     }
 }


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

This change enables the kafka-faas-connector to be configurable with environment variables. 
- If an environment variable is not set it uses a default value
- Variable names and the corresponding default values are documented in README.md
- The Variable names are the same as in the message-generator (and soon message-validator)

- [ ] this PR contains breaking changes!

# Resolves / is related to

Closes [#736](https://github.com/UST-MICO/mico/issues/736) [#745](https://github.com/UST-MICO/mico/issues/736)

# What is affected by this PR

- [ ] OpenFaaS Function Exchange Format
- [ ] Message Format
- [ ] Documentation ([Doc repository](https://github.com/UST-MICO/docs))

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
