### PR TITLE
Fix local execution of Kafka with docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.*
+**/*.md
+LICENSE
+docker-compose.yml
+kafka-faas-connector.yml

--- a/README.md
+++ b/README.md
@@ -15,17 +15,16 @@ Modify `kafka-faas-connector.yml` to set the correct URLs of the OpenFaaS gatewa
 
 ### Local execution
 
-Launch Kafka and ZooKeeper or establish a connection to already running instances (e.g. via port forwarding).
+Launch Kafka and ZooKeeper locally. Either start OpenFaaS also locally or establish a connection to an already running instance (e.g. via port forwarding).
 
 docker-compose:
 ```bash
 docker-compose up kafka zookeeper
 ```
 
-Port forwarding:
+Port forwarding to OpenFaaS:
 ```bash
-kubectl port-forward svc/kafka -n openfaas 9092
-kubectl port-forward svc/zookeeper -n openfaas 2181
+kubectl port-forward svc/gateway -n openfaas 31112:8080
 ```
 
 ## Usage
@@ -65,4 +64,16 @@ kubectl -n $NAMESPACE logs -f $(kubectl get pods -n $NAMESPACE --selector=run=ka
 Restart it by deleting the Kubernetes pod:
 ```bash
 kubectl -n $NAMESPACE delete pod $(kubectl get pods -n $NAMESPACE --selector=run=kafka-faas-connector --output=jsonpath={.items..metadata.name})
+```
+
+Produce message to topic 'transform-request' locally:
+```bash
+docker exec -it kafka /bin/bash
+/opt/kafka/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic transform-request
+```
+
+Consume topic 'transform-result' locally:
+```bash
+docker exec -it kafka /bin/bash
+/opt/kafka/bin/kafka-console-consumer.sh --bootstrap-server localhost:9092 --group mico --topic transform-result
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,13 +8,16 @@ services:
   kafka:
     image: wurstmeister/kafka
     container_name: kafka
+    hostname: kafka
     depends_on:
       - zookeeper
     ports:
       - "9092:9092"
     environment:
-      HOSTNAME_COMMAND: "curl -s ifconfig.co"
-      #KAFKA_ADVERTISED_HOST_NAME: host.docker.internal
+      KAFKA_CREATE_TOPICS: "transform-request:1:1,transform-result:1:1" # topic:partition:replicas
+      #HOSTNAME_COMMAND: "curl -s ifconfig.co"
+      KAFKA_ADVERTISED_HOST_NAME: kafka
+      KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
@@ -24,5 +27,5 @@ services:
     depends_on:
       - kafka
     environment:
-      kafka.bootstrapServers: kafka:9092
-      openfaas.gateway: http://host.docker.internal:8080
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      OPENFAAS_GATEWAY: http://host.docker.internal:31112


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Fix `docker-compose.yml` to be able to execute Kafka, ZooKeeper and Kafka-FaaS-Connector locally.

- [ ] this PR contains breaking changes!

# What is affected by this PR

- [ ] OpenFaaS Function Exchange Format
- [ ] Message Format
- [ ] Documentation ([Doc repository](https://github.com/UST-MICO/docs))

# Checklist

- [ ] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
