### PR TITLE
Change type of routing slip to linked list

### DIFF
--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/MessageListener.java
@@ -40,6 +40,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 
 @Slf4j
@@ -180,10 +181,9 @@ public class MessageListener {
      * @param cloudEvent the cloud event to send
      */
     public void sendCloudEvent(MicoCloudEventImpl<JsonNode> cloudEvent, String originalMessageId) {
-        List<List<String>> routingSlip = cloudEvent.getRoutingSlip().orElse(new ArrayList<>());
-        if (routingSlip.size() > 0) {
-            List<String> destinations = routingSlip.get(routingSlip.size() - 1);
-            routingSlip.remove(routingSlip.size() - 1);
+        LinkedList<List<String>> routingSlip = cloudEvent.getRoutingSlip().orElse(new LinkedList<>());
+        if (!routingSlip.isEmpty()) {
+            List<String> destinations = routingSlip.removeLast();
             // Check if valid topic?
             for (String topic : destinations) {
                 this.sendCloudEvent(cloudEvent, topic, originalMessageId);

--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/MicoCloudEventImpl.java
@@ -67,7 +67,7 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
     private String correlationId;
     private String createFrom;
     private List<RouteHistory> route;
-    private List<List<String>> routingSlip;
+    private LinkedList<List<String>> routingSlip;
     private Boolean isTestMessage;
     private String filterOutBeforeTopic;
     private ZonedDateTime expiryDate;
@@ -172,7 +172,7 @@ public class MicoCloudEventImpl<T> implements CloudEvent<T> {
         return Optional.ofNullable(route);
     }
 
-    public Optional<List<List<String>>> getRoutingSlip() {
+    public Optional<LinkedList<List<String>>> getRoutingSlip() {
         return Optional.ofNullable(routingSlip);
     }
 

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/CloudEventTestUtils.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/CloudEventTestUtils.java
@@ -7,6 +7,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 
@@ -77,9 +78,9 @@ public class CloudEventTestUtils {
      * @return
      */
     public static MicoCloudEventImpl<JsonNode> addMultipleTopicRoutingSteps(MicoCloudEventImpl<JsonNode> message, List<String> destinations) {
-        Optional<List<List<String>>> routingSlip = message.getRoutingSlip();
-        List<List<String>> newRoutingSlip = routingSlip.orElse(new ArrayList<>());
-        newRoutingSlip.add(destinations);
+        Optional<LinkedList<List<String>>> routingSlip = message.getRoutingSlip();
+        LinkedList<List<String>> newRoutingSlip = routingSlip.orElse(new LinkedList<>());
+        newRoutingSlip.addLast(destinations);
         return message.setRoutingSlip(newRoutingSlip);
     }
 


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Change type of the routing slip to a linked list. This makes it easier to get and remove the last destination by using the `removeLast` function.

