### PR TITLE
Bump Spring Boot to version 2.1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>io.github.ust-mico</groupId>


### PR DESCRIPTION
<!--
  For work in progress use the GitHub draft pull request feature.
-->
# Description

Update Spring Boot to version 2.1.6. Before: 2.1.5