### PR TITLE
Fix serialization of custom header fields

### DIFF
--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/UnknownExtension.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/kafka/UnknownExtension.java
@@ -19,6 +19,8 @@
 
 package io.github.ust.mico.kafkafaasconnector.kafka;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import io.cloudevents.Extension;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -31,5 +33,5 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class UnknownExtension implements Extension {
     String key;
-    String value;
+    JsonNode value;
 }


### PR DESCRIPTION
# Description

Fix de-/serialization of custom/unknown cloud event headers.

- [ ] this PR contains breaking changes!

# Resolves / is related to

<!-- Relates to #IssueNumber1, #IssueNumber2 -->
<!-- Closes #IssueNumber3 -->
<!-- Closes #IssueNumber4 -->

# What is affected by this PR

- [ ] OpenFaaS Function Exchange Format
- [x] Message Format
- [ ] Documentation ([Doc repository](https://github.com/UST-MICO/docs))

# Checklist

- [x] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
