### PR TITLE
Add random group id

### DIFF
--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -29,7 +29,7 @@ logging.level.org.apache.kafka.clients.consumer=${LOGGING_LEVEL_KAFKA_CONSUMER:I
 management.endpoints.web.exposure.include=configprops,env,health,info,loggers,metrics
 
 kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:${spring.embedded.kafka.brokers}}
-kafka.group-id=${KAFKA_GROUP_ID:TestGroup}
+kafka.group-id=${HOSTNAME:${random.uuid}}
 kafka.input-topic=${KAFKA_TOPIC_INPUT:Input}
 kafka.output-topic=${KAFKA_TOPIC_OUTPUT:Output}
 kafka.invalid-message-topic=${KAFKA_TOPIC_INVALID_MESSAGE:InvalidMessage}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -29,7 +29,7 @@ logging.level.org.apache.kafka.clients.consumer=${LOGGING_LEVEL_KAFKA_CONSUMER:I
 management.endpoints.web.exposure.include=configprops,env,health,info,loggers,metrics
 
 kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:${spring.embedded.kafka.brokers}}
-kafka.group-id=${KAFKA_GROUP_ID:mico}
+kafka.group-id=${HOSTNAME:${random.uuid}}
 kafka.input-topic=${KAFKA_TOPIC_INPUT:transform-request}
 kafka.output-topic=${KAFKA_TOPIC_OUTPUT:transform-result}
 kafka.invalid-message-topic=${KAFKA_TOPIC_INVALID_MESSAGE:InvalidMessage}

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
@@ -51,11 +51,11 @@ public class ConfigurationTests {
     @ClassRule
     public static EmbeddedKafkaRule broker = new EmbeddedKafkaRule(1, false);
 
+
     @ClassRule
     public static final EnvironmentVariables environmentVariables = new EnvironmentVariables()
         .set("OPENFAAS_FUNCTION_NAME", "openfaas_name")
         .set("OPENFAAS_GATEWAY","openfaas_gateway")
-        .set("KAFKA_GROUP_ID", "kafka_group_id")
         .set("KAFKA_TOPIC_INPUT", "kafka_in")
         .set("KAFKA_TOPIC_INVALID_MESSAGE", "kafka_invalid")
         .set("KAFKA_TOPIC_OUTPUT", "kafka_out")
@@ -78,5 +78,10 @@ public class ConfigurationTests {
         assertThat(System.getenv("KAFKA_TOPIC_INVALID_MESSAGE"), is(kafkaConfig.getInvalidMessageTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_DEAD_LETTER"), is(kafkaConfig.getDeadLetterTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_TEST_MESSAGE_OUTPUT"), is(kafkaConfig.getTestMessageOutputTopic()));
+    }
+
+    @Test
+    public void testGroupId() {
+        assertTrue(kafkaConfig.getGroupId().length() == 36);
     }
 }

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/ConfigurationTests.java
@@ -72,16 +72,11 @@ public class ConfigurationTests {
     @Test
     public void testKafkaConfig() {
         // Tests if the environment variables are injected into KafkaConfig
-        assertThat(System.getenv("KAFKA_GROUP_ID"), is(kafkaConfig.getGroupId()));
+        assertTrue(kafkaConfig.getGroupId().length() == 36);
         assertThat(System.getenv("KAFKA_TOPIC_INPUT"), is(kafkaConfig.getInputTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_OUTPUT"), is(kafkaConfig.getOutputTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_INVALID_MESSAGE"), is(kafkaConfig.getInvalidMessageTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_DEAD_LETTER"), is(kafkaConfig.getDeadLetterTopic()));
         assertThat(System.getenv("KAFKA_TOPIC_TEST_MESSAGE_OUTPUT"), is(kafkaConfig.getTestMessageOutputTopic()));
-    }
-
-    @Test
-    public void testGroupId() {
-        assertTrue(kafkaConfig.getGroupId().length() == 36);
     }
 }

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestHelper.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/MicoKafkaTestHelper.java
@@ -168,7 +168,7 @@ public class MicoKafkaTestHelper {
      * @return
      */
     public ConsumerRecord<String, MicoCloudEventImpl<JsonNode>> exchangeMessage(Consumer<String, MicoCloudEventImpl<JsonNode>> consumer, String topic, MicoCloudEventImpl<JsonNode> cloudEventSimple) {
-        template.send(kafkaConfig.getInputTopic(), "0", cloudEventSimple);
+        template.send(kafkaConfig.getInputTopic(), cloudEventSimple);
         return KafkaTestUtils.getSingleRecord(consumer, topic, DEFAULT_KAFKA_POLL_TIMEOUT);
     }
 


### PR DESCRIPTION
# Description

Sets the kafka group id to the env variable HOSTNAME and if it is not present to a random UUID.

# Resolves / is related to
Closes #847

# What is affected by this PR

- [ ] OpenFaaS Function Exchange Format
- [ ] Message Format
- [ ] Documentation ([Doc repository](https://github.com/UST-MICO/docs))

# Checklist

- [X] Ensure that new source files include the [license header](https://github.com/UST-MICO/mico/blob/master/CONTRIBUTING.md#source-file-headers)
