### PR TITLE
Remove default value for OPENFAAS_FUNCTION_NAME

### DIFF
--- a/src/main/java/io/github/ust/mico/kafkafaasconnector/messageprocessing/FaasController.java
+++ b/src/main/java/io/github/ust/mico/kafkafaasconnector/messageprocessing/FaasController.java
@@ -57,7 +57,8 @@ public class FaasController {
      * @return the result of the function call (in serialized form)
      */
     public List<MicoCloudEventImpl<JsonNode>> callFaasFunction(MicoCloudEventImpl<JsonNode> cloudEvent) throws MicoCloudEventException {
-        if (this.openFaaSConfig.isSkipFunctionCall()) {
+        if (this.openFaaSConfig.isSkipFunctionCall() || this.openFaaSConfig.getFunctionName() == null || this.openFaaSConfig.getFunctionName().isEmpty()) {
+            log.debug("Skip faas function call. Function name '{}'",this.openFaaSConfig.getFunctionName());
             return Collections.singletonList(cloudEvent);
         }
         URL functionUrl = null;

--- a/src/main/resources/application-testing.properties
+++ b/src/main/resources/application-testing.properties
@@ -36,5 +36,5 @@ kafka.invalid-message-topic=${KAFKA_TOPIC_INVALID_MESSAGE:InvalidMessage}
 kafka.dead-letter-topic=${KAFKA_TOPIC_DEAD_LETTER:DeadLetter}
 kafka.test-message-output-topic=${KAFKA_TOPIC_TEST_MESSAGE_OUTPUT:TestMessagesOutput}
 openfaas.gateway=${OPENFAAS_GATEWAY:http://127.0.0.1:8080}
-openfaas.function-name=${OPENFAAS_FUNCTION_NAME:faas-message-transformer}
+openfaas.function-name=${OPENFAAS_FUNCTION_NAME}
 openfaas.skip-function-call=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -36,4 +36,4 @@ kafka.invalid-message-topic=${KAFKA_TOPIC_INVALID_MESSAGE:InvalidMessage}
 kafka.dead-letter-topic=${KAFKA_TOPIC_DEAD_LETTER:DeadLetter}
 kafka.test-message-output-topic=${KAFKA_TOPIC_TEST_MESSAGE_OUTPUT:TestMessagesOutput}
 openfaas.gateway=${OPENFAAS_GATEWAY:http://127.0.0.1:8080}
-openfaas.function-name=${OPENFAAS_FUNCTION_NAME:faas-message-transformer}
+openfaas.function-name=${OPENFAAS_FUNCTION_NAME}

--- a/src/test/java/io/github/ust/mico/kafkafaasconnector/FaasControllerTests.java
+++ b/src/test/java/io/github/ust/mico/kafkafaasconnector/FaasControllerTests.java
@@ -20,25 +20,37 @@ package io.github.ust.mico.kafkafaasconnector;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import io.cloudevents.json.Json;
+import io.github.ust.mico.kafkafaasconnector.configuration.OpenFaaSConfig;
 import io.github.ust.mico.kafkafaasconnector.exception.MicoCloudEventException;
 import io.github.ust.mico.kafkafaasconnector.kafka.MicoCloudEventImpl;
 import io.github.ust.mico.kafkafaasconnector.messageprocessing.FaasController;
 import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Matchers.eq;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
@@ -58,6 +70,7 @@ public class FaasControllerTests {
 
     @Autowired
     FaasController faasController;
+
 
     @Test
     public void parseEmptyFunctionResult() throws MicoCloudEventException {


### PR DESCRIPTION
Removes the default value for OPENFAAS_FUNCTION_NAME and adds logic to skip the call if the value is not set.